### PR TITLE
feat: 🎸 search results will be lazy-loaded on cards

### DIFF
--- a/src/components/ResultCard.js
+++ b/src/components/ResultCard.js
@@ -1,10 +1,26 @@
 /* eslint-disable react/prop-types */
-import React, { useEffect, useState, useMemo } from 'react';
+import React, { useEffect, useState, useMemo, useRef } from 'react';
 import '../styles/ResultCard.css';
+import { observeElement } from '../utils/observerUtil';
 
 export default function ResultCard({ serviceName, checkEndpoint, spin }) {
   const [isLoading, setIsLoading] = useState(true);
   const [response, setResponse] = useState({});
+  const [isCardVisible, setIsCardVisible] = useState(false);
+  const cardRef = useRef();
+
+  useEffect(() => {
+    const observer = observeElement(([entry]) => {
+      if (entry.isIntersecting) {
+        setIsCardVisible(true);
+      }
+    });
+
+    observer.observe(cardRef.current);
+    return () => {
+      observer.unobserve(cardRef.current);
+    };
+  }, []);
 
   useEffect(() => {
     // instantiniate a new controller for this cycle
@@ -13,7 +29,7 @@ export default function ResultCard({ serviceName, checkEndpoint, spin }) {
 
     const checkUrl = window.apiUrl + checkEndpoint;
 
-    if (!spin) {
+    if (!spin && isCardVisible) {
       async function fetchAvailability() {
         setIsLoading(true);
 
@@ -39,7 +55,7 @@ export default function ResultCard({ serviceName, checkEndpoint, spin }) {
         controller.abort();
       }
     };
-  }, [checkEndpoint, spin]);
+  }, [checkEndpoint, spin, isCardVisible]);
 
   return useMemo(() => {
     const cardLoading = spin || isLoading;
@@ -62,6 +78,7 @@ export default function ResultCard({ serviceName, checkEndpoint, spin }) {
 
     return (
       <a
+        ref={cardRef}
         className={'card ' + classStatus}
         href={link}
         target={cardLoading ? undefined : '_blank'}

--- a/src/components/ResultCard.js
+++ b/src/components/ResultCard.js
@@ -15,10 +15,11 @@ export default function ResultCard({ serviceName, checkEndpoint, spin }) {
         setIsCardVisible(true);
       }
     });
+    const element = cardRef.current;
 
-    observer.observe(cardRef.current);
+    observer.observe(element);
     return () => {
-      observer.unobserve(cardRef.current);
+      observer.unobserve(element);
     };
   }, []);
 

--- a/src/utils/observerUtil.js
+++ b/src/utils/observerUtil.js
@@ -1,0 +1,9 @@
+export const observeElement = callback => {
+  if (!callback) {
+    return;
+  }
+
+  const observer = new IntersectionObserver(callback);
+
+  return observer;
+};


### PR DESCRIPTION
https://trello.com/c/LSwRxWDx/35-lazy-loading

This PR will be adding the feature of lazy-loading the search result cards on the client. 

I used the intersection observer API (https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API) which is handling the calculating/notifying us about the visibility of the cards on the screen. Whenever a card is visible on the screen, its corresponding back-end request will be fired