### PR TITLE
feat: show spinner while /services call is made

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -84,5 +84,5 @@ export default function App({ match }) {
       </>
     );
     // eslint-disable-next-line
-  }, [username, page]);
+  }, [username, services, page]);
 }

--- a/src/components/Results.js
+++ b/src/components/Results.js
@@ -45,6 +45,20 @@ export default function Results({ username, services }) {
 
   // render cards
   return useMemo(() => {
-    return <div className="results">{cards}</div>;
-  }, [cards]);
+    return <div className="results">{services.length > 0 ? cards : <CubeSpinner />}</div>;
+  }, [cards, services]);
 }
+
+const CubeSpinner = () => (
+  <div className="sk-cube-grid">
+    <div className="sk-cube sk-cube1"></div>
+    <div className="sk-cube sk-cube2"></div>
+    <div className="sk-cube sk-cube3"></div>
+    <div className="sk-cube sk-cube4"></div>
+    <div className="sk-cube sk-cube5"></div>
+    <div className="sk-cube sk-cube6"></div>
+    <div className="sk-cube sk-cube7"></div>
+    <div className="sk-cube sk-cube8"></div>
+    <div className="sk-cube sk-cube9"></div>
+  </div>
+);

--- a/src/styles/App.css
+++ b/src/styles/App.css
@@ -30,7 +30,7 @@ hr {
 #content {
   padding-top: 2%;
   padding-bottom: 2%;
-  min-height: 60vh;
+  min-height: 45vh;
 }
 
 #footer {

--- a/src/styles/Results.css
+++ b/src/styles/Results.css
@@ -1,4 +1,82 @@
-.results{
+.results {
   display: flex;
   flex-wrap: wrap;
+}
+
+/* https://tobiasahlin.com/spinkit */
+.sk-cube-grid {
+  width: 40px;
+  height: 40px;
+  margin: 100px auto;
+}
+
+.sk-cube-grid .sk-cube {
+  width: 33%;
+  height: 33%;
+  background-color: #333;
+  float: left;
+  -webkit-animation: sk-cubeGridScaleDelay 1.3s infinite ease-in-out;
+  animation: sk-cubeGridScaleDelay 1.3s infinite ease-in-out;
+}
+.sk-cube-grid .sk-cube1 {
+  -webkit-animation-delay: 0.2s;
+  animation-delay: 0.2s;
+}
+.sk-cube-grid .sk-cube2 {
+  -webkit-animation-delay: 0.3s;
+  animation-delay: 0.3s;
+}
+.sk-cube-grid .sk-cube3 {
+  -webkit-animation-delay: 0.4s;
+  animation-delay: 0.4s;
+}
+.sk-cube-grid .sk-cube4 {
+  -webkit-animation-delay: 0.1s;
+  animation-delay: 0.1s;
+}
+.sk-cube-grid .sk-cube5 {
+  -webkit-animation-delay: 0.2s;
+  animation-delay: 0.2s;
+}
+.sk-cube-grid .sk-cube6 {
+  -webkit-animation-delay: 0.3s;
+  animation-delay: 0.3s;
+}
+.sk-cube-grid .sk-cube7 {
+  -webkit-animation-delay: 0s;
+  animation-delay: 0s;
+}
+.sk-cube-grid .sk-cube8 {
+  -webkit-animation-delay: 0.1s;
+  animation-delay: 0.1s;
+}
+.sk-cube-grid .sk-cube9 {
+  -webkit-animation-delay: 0.2s;
+  animation-delay: 0.2s;
+}
+
+@-webkit-keyframes sk-cubeGridScaleDelay {
+  0%,
+  70%,
+  100% {
+    -webkit-transform: scale3D(1, 1, 1);
+    transform: scale3D(1, 1, 1);
+  }
+  35% {
+    -webkit-transform: scale3D(0, 0, 1);
+    transform: scale3D(0, 0, 1);
+  }
+}
+
+@keyframes sk-cubeGridScaleDelay {
+  0%,
+  70%,
+  100% {
+    -webkit-transform: scale3D(1, 1, 1);
+    transform: scale3D(1, 1, 1);
+  }
+  35% {
+    -webkit-transform: scale3D(0, 0, 1);
+    transform: scale3D(0, 0, 1);
+  }
 }


### PR DESCRIPTION
Show a spinner when `/services` call is delayed.

Today, when users search a username before the initial `/services` call gets completed, we show a blank screen. With this PR, there will be a spinner that indicates something is getting loaded.

**Before:**
![ius-no-spinner](https://user-images.githubusercontent.com/10065235/128089479-3a856b22-d7c9-44cc-b3d3-072227caa85a.png)



**After:**
![ius-spinning](https://user-images.githubusercontent.com/10065235/128088882-7888ddd2-9e77-4269-927d-ceef752d9b61.png)

